### PR TITLE
Adjustments after tests

### DIFF
--- a/controller/src/button_manager.py
+++ b/controller/src/button_manager.py
@@ -21,7 +21,7 @@ class ButtonManager(threading.Thread):
         threading.Thread.__init__(self)
         self.stop_event = threading.Event()
         GPIO.setwarnings(False)
-        GPIO.setmode(GPIO.BOARD)
+        GPIO.setmode(GPIO.BCM)
         GPIO.setup(LEFT_BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.setup(RIGHT_BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
@@ -44,11 +44,11 @@ class ButtonManager(threading.Thread):
 
         self.producer.close()
 
-    def _left_button_callback(self):
+    def _left_button_callback(self, *args):
         time.sleep(0.01)
         self.producer.send(KAFKA_VIEW_MANAGER_TOPIC, bytes('prev', encoding='utf-8'))
 
-    def _right_button_callback(self):
+    def _right_button_callback(self, *args):
         time.sleep(0.01)
         self.producer.send(KAFKA_VIEW_MANAGER_TOPIC, bytes('next', encoding='utf-8'))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       - epd-rpi-network
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_TICK_TIME: 3000
+      ZOOKEEPER_SYNC_LIMIT: 2
   kafka:
     image: confluentinc/cp-kafka:7.3.0
     container_name: kafka
@@ -26,6 +27,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_HEAP_OPTS: '-Xmx256M -Xms128M'
   kafdrop:
     image: obsidiandynamics/kafdrop:latest
     networks: 

--- a/epd-rpi-controller.example.cfg
+++ b/epd-rpi-controller.example.cfg
@@ -5,7 +5,7 @@ mocked_epd_width = 200
 mocked_epd_height = 200
 clear_epd_on_exit = yes
 use_buttons = no
-; both pins are physical pin numbers
+; both pins are gpio numbers - bcm mode
 left_button_pin = -1
 right_button_pin = -1
 


### PR DESCRIPTION
- changed GPIO mode to BCM, since waveshare library uses this mode
- fixed button callbacks methods
- updated docker-compose - added environment variables to achieve better performance