### PR TITLE
Update controller logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ run-ui:
 	npm run --prefix $(FRONT) dev
 
 build-docker:
-	docker-compose --profile all build
+	docker compose --profile all build
 
 run-docker:
 	docker compose up -d

--- a/controller/.pylintrc
+++ b/controller/.pylintrc
@@ -298,7 +298,7 @@ max-public-methods=20
 max-returns=6
 
 # Maximum number of statements in function / method body.
-max-statements=50
+max-statements=55
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2

--- a/controller/custom_views/Readme.md
+++ b/controller/custom_views/Readme.md
@@ -12,7 +12,7 @@ Every custom view must be a child of `View` class. Also a method `show` must be 
 In addition a **fallback** can be displayed if a `show` method will fail with an exception. To achieve this:
 
 - `show` method bust be decorated with `@View.fallback` decorator and
-- `fallback_show` method which displays fallback view must be defined
+- `_fallback` method which displays fallback view must be defined
 
 ### Arguments passed to a constructor
 

--- a/controller/custom_views/example.py
+++ b/controller/custom_views/example.py
@@ -18,20 +18,7 @@ class DummyView(View):
     """
     dummy view
     """
-    @view_fallback
-    def show(self, first_call):
-        logger.info('%s is running', self.name)
-        time.sleep(2)
-
-        image = Image.new('1', (self.epd.width, self.epd.height), 255)
-        draw = ImageDraw.Draw(image)
-        font = ImageFont.truetype('/usr/share/fonts/truetype/msttcorefonts/Impact.ttf', self.epd.width//10)
-        draw.text((self.epd.width//20, self.epd.height//20), f'Hello\nWorld from\n{self.name}', font=font, fill=0)
-        self.image = image
-        self._rotate_image()
-        self.epd.display(self.epd.getbuffer(self.image))
-
-    def fallback_show(self, *args, **kwargs):
+    def _fallback(self, *args, **kwargs):
         logger.info('%s fallback is running', self.name)
         image = Image.new('1', (self.epd.width, self.epd.height), 255)
         draw = ImageDraw.Draw(image)
@@ -43,20 +30,47 @@ class DummyView(View):
         self.epd.display(self.epd.getbuffer(self.image))
         logger.info('EPD updated with fallback for %s', self.name)
 
+    @view_fallback
+    def _epd_change(self, first_call):
+        logger.info('%s is running', self.name)
+        time.sleep(2)
+        image = Image.new('1', (self.epd.width, self.epd.height), 255)
+        draw = ImageDraw.Draw(image)
+        font = ImageFont.truetype('/usr/share/fonts/truetype/msttcorefonts/Impact.ttf', self.epd.width//10)
+        draw.text((self.epd.width//20, self.epd.height//20), f'Hello\nWorld from\n{self.name}', font=font, fill=0)
+        self.image = image
+        self._rotate_image()
+        self.epd.display(self.epd.getbuffer(self.image))
+        logger.info('EPD updated with %s', self.name)
+
 
 class BrokenDummyView(DummyView):
     """
     broken dummy view
     """
     @view_fallback
-    def show(self, first_call):
+    def _epd_change(self, first_call):
         raise NotImplementedError
 
+
+class ConditionalDummyView(DummyView):
+    """
+    conditional dummy view
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.switch = False
+
+    def _conditional(self, *args, **kwargs):
+        self.switch = not self.switch
+        if bool(kwargs['first_call']) or self.switch:
+            return True
+        return False
 
 VIEWS = [
     DummyView('Dummy view 1', 0),
     DummyView('Dummy view 2', 6, 180),
     DummyView('Dummy view 3', 0),
-    DummyView('Dummy view 4', 7),
+    ConditionalDummyView('Dummy view 4', 7),
     BrokenDummyView('Broken dummy view 5', 0)
 ]

--- a/controller/main.py
+++ b/controller/main.py
@@ -39,7 +39,8 @@ def main():
         from src import MockedEPD
         epd = MockedEPD(width=Config.MOCKED_EPD_WIDTH, height=Config.MOCKED_EPD_HEIGHT)
     else:
-        epd = importlib.import_module(f'waveshare_epd_driver.{Config.EPD_MODEL}.EPD')
+        epd_package = importlib.import_module(f'waveshare_epd_driver.{Config.EPD_MODEL}')
+        epd = epd_package.EPD()
 
     if Config.USE_BUTTONS:
         from src import ButtonManager

--- a/controller/src/api/handlers.py
+++ b/controller/src/api/handlers.py
@@ -4,6 +4,7 @@ import io
 import tornado.web
 from PIL import Image
 
+from config import Config
 from .models import StatusModel, CurrentDisplayModel  # pylint: disable=W0611 # noqa: F401
 
 
@@ -133,6 +134,7 @@ class CurrentDisplayHandler(BaseHandler):
         if not current_image or not isinstance(current_image, Image.Image):
             self.set_status(400, "Returning current display failed.")
             return
+        current_image = current_image.rotate(-Config.VIEW_ANGLE)
         current_image_buffer = io.BytesIO()
         current_image.save(current_image_buffer, format="JPEG")
         current_image_bytes = current_image_buffer.getvalue()

--- a/controller/src/helpers.py
+++ b/controller/src/helpers.py
@@ -23,7 +23,7 @@ def signal_handler(thread, *args):
 
 # pylint: disable=E1102,W0703
 def view_fallback(func):
-    """Function triggers fallback_show method of View object if a show method fails"""
+    """Function triggers _fallback method of View object if a _epd_change method fails"""
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         view_object = args[0]
@@ -31,5 +31,16 @@ def view_fallback(func):
             func(*args, **kwargs)
         except Exception:
             logger.exception('Error occured in %s, calling fallback', view_object.name)
-            view_object.fallback_show(*args, **kwargs)
+            view_object._fallback(*args, **kwargs)
+    return wrapper
+
+
+# pylint: disable=E1102,W0703
+def view_conditional(func):
+    """Function triggers _epd_change method of View object only when _conditional method returns True"""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        view_object = args[0]
+        if view_object._conditional(*args, **kwargs):
+            func(*args, **kwargs)
     return wrapper

--- a/controller/src/view.py
+++ b/controller/src/view.py
@@ -1,9 +1,11 @@
 """Module exports View class"""
 
+from datetime import datetime
 import logging
 from PIL import Image
 
 from config import Config
+from src.helpers import view_conditional
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -15,7 +17,7 @@ class View:
     To display the data on EPD an instance of View must be created.
     Also a show method must be implemented to display desired informations
     on a EPD device. To support fallback view (in case of show method failure)
-    additionally a fallback_show method must be implemented.
+    additionally a _fallback method must be implemented.
     """
 
     def __init__(self, name, interval, view_angle=Config.VIEW_ANGLE):
@@ -25,16 +27,46 @@ class View:
         self.interval = interval
         self.image = None
         self.view_angle = view_angle
+        self.timestamp = None
+        self.busy = False
 
+    @view_conditional
     def show(self, first_call):
+        """Method is an entrypoint to display informations on EPD device.
+        It sets certain properties of the current view and runs a method which operates
+        directly on the EPD.
+        """
+        self._before_epd_change()
+        self._epd_change(first_call)
+        self._after_epd_change()
+
+    def _before_epd_change(self):
+        """Method sets view as busy before EPD change"""
+        self.busy = True
+
+    def _epd_change(self, first_call):
         """Method displays desired informations on a EPD device"""
         raise NotImplementedError
+
+    def _after_epd_change(self):
+        """Method sets view as idle and sets timestamp after EPD change"""
+        self._set_timestamp()
+        self.busy = False
 
     def _rotate_image(self):
         """Method rotates by configured angle and updates the image"""
         if self.image and isinstance(self.image, Image.Image):
             self.image = self.image.rotate(self.view_angle)
 
-    def fallback_show(self, *args, **kwargs):
-        """Method shows a fallback view if a show method fails"""
+    def _set_timestamp(self):
+        """Method sets a timestamp"""
+        current_date = datetime.now()
+        self.timestamp = current_date.strftime("%Y-%m-%d, %H:%M:%S")
+
+    def _fallback(self, *args, **kwargs):
+        """Method shows a fallback view if a _epd_change method fails"""
         raise NotImplementedError
+
+    def _conditional(self, *args, **kwargs):
+        """Method used to trigger EPD change only under certain conditions"""
+        return True

--- a/controller/src/view_manager.py
+++ b/controller/src/view_manager.py
@@ -2,7 +2,6 @@
 
 import threading
 import logging
-from datetime import datetime
 
 from waiting import wait, TimeoutExpired
 
@@ -72,7 +71,6 @@ class ViewManager(threading.Thread):
                 self.busy.set()
                 logger.debug('\tView is running')
                 self.views[self.current_view].show(first_call=first_call)
-                self._set_timestamp()
                 logger.debug('\tView is idle')
                 self.busy.clear()
                 if self.views[self.current_view].interval == 0:
@@ -94,17 +92,12 @@ class ViewManager(threading.Thread):
     def epd_status(self):
         """Method returns EPD's current status"""
         return {
-            'epd_busy': self.busy.is_set(),
+            'epd_busy': self.views[self.current_view].busy,
             'current_view': self.current_view,
             'total_views': len(self.views),
-            'timestamp': self.timestamp
+            'timestamp': self.views[self.current_view].timestamp
         }
 
     def current_display(self):
         """Method returns EPD's currently displayed image"""
         return self.views[self.current_view].image
-
-    def _set_timestamp(self):
-        """Method sets a timestamp"""
-        current_date = datetime.now()
-        self.timestamp = current_date.strftime("%Y-%m-%d, %H:%M:%S")

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,7 +57,7 @@
       clearInterval(this.interval)
       this.interval = setInterval(() => {
         this.fetchStatus()
-      }, 1000)
+      }, 600)
     }
   },
 }

--- a/front/src/components/AppMain.vue
+++ b/front/src/components/AppMain.vue
@@ -12,7 +12,7 @@
       justify="center"
     >
       <v-col
-        cols="12"
+        cols="10"
         md="8"
         xl="6"
         class="mb-1 text-center"
@@ -24,7 +24,6 @@
         >
           <v-col
             sm="6"
-            md="4"
             xl="3"
             class="mb-1 text-center"
             justify="space-between"

--- a/front/src/stores/epdStatus.js
+++ b/front/src/stores/epdStatus.js
@@ -24,6 +24,10 @@ export const useEpdStatusStore = defineStore({
           return response.json()
         })
         .then( data => {
+          if ( data.epd_busy ) {
+            this.epdBusy = true
+            return
+          }
           if ( this.timestamp !== data.timestamp ) {
             uiStatusStore.$patch({
               loadingImage: true


### PR DESCRIPTION
View class changed - added few new methods and rearranged logic. From now each view will switch internally its busy status and timestamp using additional methods:
- `_before_epd_change`
- `_epd_change`
- `_after_epd_change`

and decorators `_conditional` and `_fallback`.

Thanks to this update a view is busy only when it is operating directly on a EPD device. This is crucial when changes should happen conditionally. And hence - a proper information about view's state is passed through API and properly displayed on the UI layer.