### PR TITLE
Revert "Bump tornado from 6.3.2 to 6.3.3 in /controller (#51)"

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -6,7 +6,7 @@ python-dotenv==0.21.0
 Pillow==9.3.0
 RPi.GPIO==0.7.1
 spidev==3.5
-tornado==6.3.3
+tornado==6.3.2
 tornado-swagger==1.4.5
 waiting==1.4.1
 waveshare-epd-driver==1.0.0


### PR DESCRIPTION
This reverts commit ca75a9d23b605e6f9715c201e6863d50d309b08d.