### PR TITLE
Fix RPi.GPIO issue

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -4,7 +4,7 @@ mypy_extensions==1.0.0
 Mock.GPIO==0.1.8
 python-dotenv==0.21.0
 Pillow==9.3.0
-RPi.GPIO==0.7.1
+RPi.GPIO2
 spidev==3.5
 tornado==6.3.3
 tornado-swagger==1.4.5


### PR DESCRIPTION
Apparently there's a strange issue with `RPi.GPIO` library and Python 3.11 which ends with: `Could not determine Jetson model` error. A workaround - install RPi.GPIO2 first and then install RPi.GPIO using `--force-reinstall` option: `pip install --upgrade --force-reinstall RPi.GPIO`.

Also within this PR removed some redundant commands from Makefile.